### PR TITLE
adding destroy burning and Types for Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ Right now we are using unsigned 64-bit fixed point numbers `UFix64` as the type 
 - Conditions:
     - the balance of the returned Vault must be 0
 
-6 - Standard for Token Metadata
+6 - Destroying a Vault
+
+If a `Vault` is explicitly destroyed using Cadence's `destroy` keyword, the balance of the destroyed vault must be subracted from the total supply.
+
+7 - Standard for Token Metadata
 
 - not sure what this should be yet
 - Could be a dictionary, could be an IPFS hash, could be json, etc.

--- a/contracts/FlowToken.cdc
+++ b/contracts/FlowToken.cdc
@@ -71,7 +71,7 @@ pub contract FlowToken: FungibleToken {
         // created Vault to the context that called so it can be deposited
         // elsewhere.
         //
-        pub fun withdraw(amount: UFix64): @Vault {
+        pub fun withdraw(amount: UFix64): @FlowToken.Vault {
             self.balance = self.balance - amount
             emit Withdraw(amount: amount, from: self.owner?.address)
             return <-create Vault(balance: amount)
@@ -84,10 +84,15 @@ pub contract FlowToken: FungibleToken {
         // It is allowed to destroy the sent Vault because the Vault
         // was a temporary holder of the tokens. The Vault's balance has
         // been consumed and therefore can be destroyed.
-        pub fun deposit(from: @Vault) {
+        pub fun deposit(from: @FlowToken.Vault) {
             self.balance = self.balance + from.balance
             emit Deposit(amount: from.balance, to: self.owner?.address)
+            from.balance = 0.0
             destroy from
+        }
+
+        destroy() {
+            FlowToken.totalSupply = FlowToken.totalSupply - self.balance
         }
     }
 
@@ -98,7 +103,7 @@ pub contract FlowToken: FungibleToken {
     // and store the returned Vault in their storage in order to allow their
     // account to be able to receive deposits of this token type.
     //
-    pub fun createEmptyVault(): @Vault {
+    pub fun createEmptyVault(): @FlowToken.Vault {
         return <-create Vault(balance: 0.0)
     }
 
@@ -117,7 +122,7 @@ pub contract FlowToken: FungibleToken {
         // Function that mints new tokens, adds them to the total Supply,
         // and returns them to the calling context
         //
-        pub fun mintTokens(amount: UFix64): @Vault {
+        pub fun mintTokens(amount: UFix64): @FlowToken.Vault {
             pre {
                 amount > UFix64(0): "Amount minted must be greater than zero"
                 amount <= self.allowedAmount: "Amount minted must be less than the allowed amount"
@@ -136,9 +141,8 @@ pub contract FlowToken: FungibleToken {
         //
         // Returns the amount that was burnt.
         //
-        pub fun burnTokens(from: @Vault): UFix64 {
+        pub fun burnTokens(from: @FlowToken.Vault): UFix64 {
             let amount = from.balance
-            FlowToken.totalSupply = FlowToken.totalSupply - from.balance
             destroy from
             emit Burn(amount: amount)
             return amount
@@ -198,3 +202,4 @@ pub contract FlowToken: FungibleToken {
     }
 }
 
+ 

--- a/transactions/burn_tokens.cdc
+++ b/transactions/burn_tokens.cdc
@@ -21,7 +21,8 @@ transaction {
             .withdraw(amount: 10.0)
 
         // Create a reference to the admin MintAndBurn resource in storage
-        self.mintAndBurn = signer.borrow<&FlowToken.MintAndBurn>(from: /storage/flowTokenMintAndBurn)!
+        self.mintAndBurn = signer.borrow<&FlowToken.MintAndBurn>(from: /storage/flowTokenMintAndBurn)
+            ?? panic("Could not borrow a reference to the Burn resource")
     }
 
     execute {

--- a/transactions/create_forwarder.cdc
+++ b/transactions/create_forwarder.cdc
@@ -37,7 +37,8 @@ transaction {
 
         let recipientReceiver = recipient
             .getCapability(/public/flowTokenReceiver)!
-            .borrow<&{FungibleToken.Receiver}>()!
+            .borrow<&{FungibleToken.Receiver}>()
+            ?? panic("Could not borrow receiver reference from the capability")
 
         // Create a new Forwarder resource and store it in the signer's storage
         let forwarder <- TokenForwarding.createNewForwarder(recipient: recipientReceiver)
@@ -50,3 +51,4 @@ transaction {
         )
     }
 }
+ 

--- a/transactions/custodial_deposit.cdc
+++ b/transactions/custodial_deposit.cdc
@@ -40,7 +40,8 @@ transaction {
 
         let receiver = recipient
             .getCapability(/public/depositResourcePublic)!
-            .borrow<&{CustodialDeposit.DepositPublic}>()!
+            .borrow<&{CustodialDeposit.DepositPublic}>()
+            ?? panic("Could not borrow deposit reference from capability")
 
         // Deposit the withdrawn tokens to the recipient's Receiver.
         // Include a tag for the event that is emitted
@@ -48,3 +49,4 @@ transaction {
         receiver.taggedDeposit(from: <-self.sentVault, tag: "1234")
     }
 }
+ 

--- a/transactions/get_balance.cdc
+++ b/transactions/get_balance.cdc
@@ -6,7 +6,7 @@ import FlowToken from 0x02
 pub fun main(): UFix64 {
 
     // Get the public account object of the account
-    let account = getAccount(0x02)
+    let account = getAccount(0x03)
 
     // Retrieve their public Balance reference from their account
     let balanceRef = account

--- a/transactions/mint_tokens.cdc
+++ b/transactions/mint_tokens.cdc
@@ -35,3 +35,4 @@ transaction {
         receiver.deposit(from: <-self.vault)
     }
 }
+ 

--- a/transactions/transfer_tokens.cdc
+++ b/transactions/transfer_tokens.cdc
@@ -16,7 +16,8 @@ transaction {
     prepare(signer: AuthAccount) {
 
         // Get a reference to the signer's stored vault
-        let storedVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)!
+        let storedVault = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Unable to borrow a reference to the sender's Vault")
 
         // Withdraw 10 tokens from the signer's stored vault
         self.sentVault <- storedVault.withdraw(amount: 10.0)
@@ -30,9 +31,11 @@ transaction {
         // Get a reference to the recipient's Receiver
         let receiver = recipient
             .getCapability(/public/flowTokenReceiver)!
-            .borrow<&{FungibleToken.Receiver}>()!
+            .borrow<&{FungibleToken.Receiver}>() 
+            ?? panic("Unable to borrow receiver reference for recipient")
 
         // Deposit the withdrawn tokens in the recipient's receiver
         receiver.deposit(from: <-self.sentVault)
     }
 }
+ 


### PR DESCRIPTION
Make a few changes:

* Changed `deposit` and `destroy` so that we could subtract the destroyed balance when a vault is destroyed
* Added failable downcasting for deposit Vault to make sure it is the correct Vault type
* Changed some optionals to have nil-coalescing instead of force-unwrap