### PR TITLE
contracts: Remove dependency on flow-go-sdk

### DIFF
--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -9,21 +9,21 @@ import (
 )
 
 const (
-	FungibleTokenContractFilename = "FungibleToken.cdc"
-	FlowTokenContractFilename     = "FlowToken.cdc"
-	defaultFungibleTokenAddress   = "02"
+	fungibleTokenFilename       = "FungibleToken.cdc"
+	flowTokenFilename           = "FlowToken.cdc"
+	defaultFungibleTokenAddress = "02"
 )
 
 // FungibleToken returns the FungibleToken contract interface.
 func FungibleToken() []byte {
-	return assets.MustAsset(FungibleTokenContractFilename)
+	return assets.MustAsset(fungibleTokenFilename)
 }
 
 // FlowToken returns the FlowToken contract.
 //
 // The returned contract will import the FungibleToken contract from the specified address.
 func FlowToken(fungibleTokenAddr string) []byte {
-	code := assets.MustAssetString(FlowTokenContractFilename)
+	code := assets.MustAssetString(flowTokenFilename)
 
 	code = strings.ReplaceAll(
 		code,

--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -1,11 +1,11 @@
 package contracts
 
-//go:generate go run github.com/kevinburke/go-bindata/go-bindata -prefix ../src/contracts -o assets.go -pkg contracts -nometadata -nomemcopy ../src/contracts
+//go:generate go run github.com/kevinburke/go-bindata/go-bindata -prefix ../src/contracts -o internal/assets/assets.go -pkg assets -nometadata -nomemcopy ../src/contracts
 
 import (
 	"strings"
 
-	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-ft/contracts/internal/assets"
 )
 
 const (
@@ -16,19 +16,19 @@ const (
 
 // FungibleToken returns the FungibleToken contract interface.
 func FungibleToken() []byte {
-	return MustAsset(FungibleTokenContractFilename)
+	return assets.MustAsset(FungibleTokenContractFilename)
 }
 
-// FlowToken returns the FlowToken contract. importing the
+// FlowToken returns the FlowToken contract.
 //
 // The returned contract will import the FungibleToken contract from the specified address.
-func FlowToken(fungibleTokenAddress flow.Address) []byte {
-	code := MustAssetString(FlowTokenContractFilename)
+func FlowToken(fungibleTokenAddr string) []byte {
+	code := assets.MustAssetString(FlowTokenContractFilename)
 
 	code = strings.ReplaceAll(
 		code,
 		"0x"+defaultFungibleTokenAddress,
-		"0x"+fungibleTokenAddress.Hex(),
+		"0x"+fungibleTokenAddr,
 	)
 
 	return []byte(code)

--- a/contracts/contracts_test.go
+++ b/contracts/contracts_test.go
@@ -3,10 +3,13 @@ package contracts_test
 import (
 	"testing"
 
-	"github.com/onflow/flow-ft/contracts"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-ft/contracts"
 )
+
+var addrA = flow.HexToAddress("0A")
 
 func TestFungibleTokenContract(t *testing.T) {
 	contract := contracts.FungibleToken()
@@ -14,7 +17,7 @@ func TestFungibleTokenContract(t *testing.T) {
 }
 
 func TestFlowTokenContract(t *testing.T) {
-	contract := contracts.FlowToken(flow.Address{0x3})
+	contract := contracts.FlowToken(addrA.Hex())
 	assert.NotNil(t, contract)
-	assert.Contains(t, string(contract), "0x03")
+	assert.Contains(t, string(contract), addrA.Hex())
 }

--- a/contracts/internal/assets/assets.go
+++ b/contracts/internal/assets/assets.go
@@ -5,7 +5,7 @@
 // ../src/contracts/FungibleToken.cdc (7.298kB)
 // ../src/contracts/TokenForwarding.cdc (1.954kB)
 
-package contracts
+package assets
 
 import (
 	"bytes"


### PR DESCRIPTION
This avoids forcing the caller to use the `Address` type from `flow-go-sdk`, which isn't ideal for the `flow-go` repo.